### PR TITLE
feat(pdf): added option to disable print and save buttons via query p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,9 +2775,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3740,10 +3740,11 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7627,10 +7628,11 @@
       "license": "MIT"
     },
     "node_modules/jasmine/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8592,9 +8594,9 @@
       }
     },
     "node_modules/metalsmith-html-relative/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11387,9 +11389,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/app.js
+++ b/web/app.js
@@ -782,7 +782,10 @@ const PDFViewerApplication = {
         console.warn(msg);
       });
     }
-
+    if (AppOptions.get("disableSaving")) {
+      appConfig.toolbar?.download?.classList.add("hidden");
+      appConfig.secondaryToolbar?.downloadButton.classList.add("hidden");
+    }
     if (!this.supportsPrinting) {
       appConfig.toolbar?.print?.classList.add("hidden");
       appConfig.secondaryToolbar?.printButton.classList.add("hidden");
@@ -1187,6 +1190,9 @@ const PDFViewerApplication = {
   },
 
   async download() {
+    if (AppOptions.get("disableSaving")) {
+      return;
+    }
     let data;
     try {
       data = await (this.pdfDocument
@@ -1199,6 +1205,9 @@ const PDFViewerApplication = {
   },
 
   async save() {
+    if (AppOptions.get("disableSaving")) {
+      return;
+    }
     if (this._saveInProgress) {
       return;
     }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -203,6 +203,11 @@ const defaultOptions = {
     value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
+  disableSaving: {
+    /** @type {boolean} */
+    value: false,
+    kind: OptionKind.VIEWER,
+  },
   enableAltText: {
     /** @type {boolean} */
     value: false,

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -34,6 +34,23 @@ window.PDFViewerApplication = PDFViewerApplication;
 window.PDFViewerApplicationConstants = AppConstants;
 window.PDFViewerApplicationOptions = AppOptions;
 
+const flipConfigParam = new URLSearchParams(window.location.search).get(
+  "flipconfig"
+);
+if (flipConfigParam) {
+  try {
+    const flipConfig = JSON.parse(atob(flipConfigParam));
+    if (flipConfig.disablePrint === true) {
+      window.PDFViewerApplicationOptions.set("supportsPrinting", false);
+    }
+    if (flipConfig.disableSave === true) {
+      window.PDFViewerApplicationOptions.set("disableSaving", true);
+    }
+  } catch (e) {
+    console.warn("Invalid config param", e);
+  }
+}
+
 function getViewerConfiguration() {
   return {
     appContainer: document.body,


### PR DESCRIPTION
This PR adds the possibility to disable the print and download buttons on the PDF viewer via query params

### Changes proposed in this pull request:
- Added new app options
- Dynamically hides the buttons
- Dynamically disables printing and saving

### References:
#[WEB-5707](https://linear.app/jobylon/issue/WEB-5707/disable-pdf-file-downloadprint-buttons)

### Browser compatibility:
The UI (CSS/JS) has been tested on the following browsers (browserstack.com):
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE11
- [x] Safari