### PR TITLE
feat(pdf): change enableScripting to false

### DIFF
--- a/web/viewer.mjs
+++ b/web/viewer.mjs
@@ -735,7 +735,7 @@ const defaultOptions = {
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   enableScripting: {
-    value: true,
+    value: false,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   enableSignatureEditor: {


### PR DESCRIPTION
This PR disables JavaScript execution in the PDF viewer by turning off the `enableScripting` option by default.

### Changes proposed in this pull request:
- Set the `enableScripting` app option default to `false`

### References:
[WEB-8857](https://linear.app/jobylon/issue/WEB-8857/ensure-pdf-scanning-for-embedded-javascript)

### Browser compatibility:
The UI (CSS/JS) has been tested on the following browsers (browserstack.com):
- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE11
- [ ] Safari